### PR TITLE
Link documents to categories

### DIFF
--- a/server/routes/categories.js
+++ b/server/routes/categories.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../db');
+
+// GET /api/categories - ดึงรายการหมวดหมู่ทั้งหมด
+router.get('/', (req, res) => {
+  db.query('SELECT categorie_id, name FROM categories ORDER BY name', (err, rows) => {
+    if (err) {
+      console.error('DB error (categories):', err);
+      return res.status(500).json({ message: 'เกิดข้อผิดพลาดในการดึงหมวดหมู่' });
+    }
+    res.json(rows);
+  });
+});
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,7 @@ const signupRoute = require("./routes/signup");
 const authRoute = require("./routes/auth");
 const filesRoute = require('./routes/files');
 const sectionFilesRoute = require('./routes/sectionFiles');
+const categoriesRoute = require('./routes/categories');
 const uploadRoute = require("./routes/upload");
 
 // ...ส่วนอื่น ๆ ของ server.js
@@ -43,6 +44,7 @@ app.use("/api/auth", authRoute);
 
 app.use('/files', filesRoute);
 app.use('/api', sectionFilesRoute);
+app.use('/api/categories', categoriesRoute);
 
 app.get('/', (req, res) => {
   res.send('Welcome to the API server');


### PR DESCRIPTION
Allow documents to be associated with multiple categories by fetching categories from the database and providing a multi-select UI.

The original system used a single free-text field for "category" which was not linked to a predefined list. This change implements a many-to-many relationship between documents and categories, using a dedicated `categories` table, to enable more structured categorization and improve data consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-c58ec5cb-c947-43cf-8bff-67947e8ca3e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c58ec5cb-c947-43cf-8bff-67947e8ca3e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

